### PR TITLE
Add Redis Cache resource to Bicep template

### DIFF
--- a/src/InfrastructureAsCode/main.bicep
+++ b/src/InfrastructureAsCode/main.bicep
@@ -13,7 +13,25 @@ var registryName = '${uniqueString(resourceGroup().id)}mpnpreg'
 var registrySku = 'Standard'
 var imageName = 'techexcel/dotnetcoreapp'
 var startupCommand = ''
+var redisCacheName = '${uniqueString(resourceGroup().id)}-mpnp-redis'
+var redisCacheSku = 'Basic'
 
+resource redisCache 'Microsoft.Cache/Redis@2023-08-01' = {
+  name: redisCacheName
+  location: location
+  properties: {
+    sku: {
+      name: redisCacheSku
+      family: 'C'
+      capacity: 0
+    }
+    enableNonSslPort: false
+    minimumTlsVersion: '1.2'
+    redisConfiguration: {
+      'maxmemory-policy': 'volatile-lru'
+    }
+  }
+}
 
 resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2021-12-01-preview' = {
   name: logAnalyticsName


### PR DESCRIPTION
This pull request includes changes to the `src/InfrastructureAsCode/main.bicep` file to add support for a Redis cache. The most important changes include defining new variables for the Redis cache name and SKU, and adding a new resource block for the Redis cache.

Additions for Redis cache support:

* [`src/InfrastructureAsCode/main.bicep`](diffhunk://#diff-a705772ad6c700e9d296ea9fb26de5e54a731a73bf57caf1f56f6bb3dbed2869R16-R34): Added variables `redisCacheName` and `redisCacheSku` to define the Redis cache name and SKU.
* [`src/InfrastructureAsCode/main.bicep`](diffhunk://#diff-a705772ad6c700e9d296ea9fb26de5e54a731a73bf57caf1f56f6bb3dbed2869R16-R34): Added a new resource block for `Microsoft.Cache/Redis` to provision a Redis cache with specified properties such as SKU, TLS version, and memory policy.